### PR TITLE
[grammar] make the EBNF grammar file pretty

### DIFF
--- a/tins.ebnf
+++ b/tins.ebnf
@@ -1,10 +1,10 @@
 program = importStmt | varDefStmt | funcDef
 
 (* import语句不可换行 *)
-importStmt = IMPORT ID.ID.ID
+importStmt = IMPORT ID '.' ID '.' ID
 
 varDef = TYPE ID
-       | TYPE[] ID '=' expr
+       | TYPE '[' ']' ID '=' expr
 
 structDef = STRUCT ID '{' varDef, funcDef '}'
 
@@ -44,7 +44,7 @@ OP_ASSIGN = '='
           | '<<='
           | '>>='
 
-condExpr = logicOrExpr ? assignExpr : condExpr
+condExpr = logicOrExpr '?' assignExpr ':' condExpr
          | logicOrExpr
 
 logicOrExpr = logicOrExpr '||' logicAndExpr
@@ -102,6 +102,6 @@ factorExpr = factorExpr '.' ID
            | callFuncExpr
            | ID
            | NUM_VAL | STRING_VAL | CHAR_VAL | DOUBLE_VAL | FLOAT_VAL
-           | (expr)
+           | '(' expr ')'
 
 callFuncExpr = ID '(' param ')'

--- a/tins.ebnf
+++ b/tins.ebnf
@@ -1,67 +1,107 @@
 program = importStmt | varDefStmt | funcDef
 
-# import语句不可换行
-importStmt -> IMPORT ID.ID.ID
-varDef -> TYPE ID | TYPE[] ID = expr
-structDef -> STRUCT ID { varDef, funcDef }
-funcDef -> TYPE ID funcParam funcBody
-funcParam = ( TYPE ID, TYPE ID)
-funcBody -> stmt
-stmt -> ifStmt | whileStmt | forStmt | switchStmt | breakStmt | continueStmt | returnStmt | expr | emptyStmt
+(* import语句不可换行 *)
+importStmt = IMPORT ID.ID.ID
 
-# 表达式解析
-expr -> assignExpr
+varDef = TYPE ID
+       | TYPE[] ID '=' expr
 
-# todo assignExpr -> factorExpr OP_ASSIGN assignExpr
-assignExpr -> condExpr OP_ASSIGN assignExpr #偷个懒
-            | condExpr
+structDef = STRUCT ID '{' varDef, funcDef '}'
 
-字符串运算的+=特殊处理
-OP_ASSIGN -> = | += | -= | *= | /= | %= | &= | '|=' | ^= | <<= | >>=
+funcDef = TYPE ID funcParam funcBody
 
-condExpr -> logicOrExpr ? assignExpr : condExpr
-            | logicOrExpr
-logicOrExpr -> logicOrExpr || logicAndExpr
+funcParam = '(' TYPE ID, ',', TYPE ID ')'
+
+funcBody = stmt
+
+stmt = ifStmt
+     | whileStmt
+     | forStmt
+     | switchStmt
+     | breakStmt
+     | continueStmt
+     | returnStmt
+     | expr
+     | emptyStmt
+
+(* 表达式解析 *)
+expr = assignExpr
+
+(* TODO: assignExpr -> factorExpr OP_ASSIGN assignExpr *)
+assignExpr = condExpr OP_ASSIGN assignExpr
+           | condExpr
+
+(* 字符串运算的+=特殊处理 *)
+OP_ASSIGN = '='
+          | '+='
+          | '-='
+          | '*='
+          | '/='
+          | '%='
+          | '&='
+          | '|='
+          | '^='
+          | '<<='
+          | '>>='
+
+condExpr = logicOrExpr ? assignExpr : condExpr
+         | logicOrExpr
+
+logicOrExpr = logicOrExpr '||' logicAndExpr
             | logicAndExpr
-logicAndExpr -> logicAndExpr && bitOrExpr
-            | bitOrExpr
-bitOrExpr -> bitOrExpr | bitXorExpr
-            | bitXorExpr
-bitXorExpr -> bitXorExpr ^ bitAndExpr
-            | bitAndExpr
-bitAndExpr -> bitAndExpr & equalityExpr
-            | equalityExpr
-equalityExpr -> equalityExpr == relationExpr
-            | equalityExpr != relationExpr
-            | relationExpr
-relationExpr -> shiftExpr > shiftExpr
-            | shiftExpr >= shiftExpr
-            | shiftExpr < shiftExpr
-            | shiftExpr <= shiftExpr
-            | shiftExpr
-shiftExpr -> shiftExpr << addOrSubExpr
-            | shiftExpr >> addOrSubExpr
-            | addOrSubExpr
-addOrSubExpr -> addOrSubExpr + mulOrDivExpr 字符串运算特殊处理
-            | addOrSubExpr - mulOrDivExpr
-            | mulOrDivExpr
-mulOrDivExpr -> mulOrDivExpr * suffixUnaryExpr
-            | mulOrDivExpr / suffixUnaryExpr
-            | suffixUnaryExpr
-suffixUnaryExpr -> prefixUnaryExpr ++
-            | prefixUnaryExpr --
-            | prefixUnaryExpr
-prefixUnaryExpr -> - factorExpr 取负数
-            | ~ prefixUnaryExpr 按位取反
-            | ++ factorExpr
-            | -- factorExpr
-            | ! prefixUnaryExpr
-            | (TYPE) prefixUnaryExpr 类型转换表达式，可递归
-            | factorExpr
-factorExpr -> factorExpr.ID
-            | factorExpr[expr]
-            | callFuncExpr
-            | ID
-            | NUM_VAL | STRING_VAL | CHAR_VAL | DOUBLE_VAL | FLOAT_VAL 各种常量
-            | (expr)
-callFuncExpr -> ID(param)
+
+logicAndExpr = logicAndExpr '&&' bitOrExpr
+             | bitOrExpr
+
+bitOrExpr = bitOrExpr
+          | bitXorExpr
+          | bitXorExpr
+
+bitXorExpr = bitXorExpr '^' bitAndExpr
+           | bitAndExpr
+
+bitAndExpr = bitAndExpr '&' equalityExpr
+           | equalityExpr
+
+equalityExpr = equalityExpr '==' relationExpr
+             | equalityExpr '!=' relationExpr
+             | relationExpr
+
+relationExpr = shiftExpr '>' shiftExpr
+             | shiftExpr '>=' shiftExpr
+             | shiftExpr '<' shiftExpr
+             | shiftExpr '<=' shiftExpr
+             | shiftExpr
+
+shiftExpr = shiftExpr '<<' addOrSubExpr
+          | shiftExpr '>>' addOrSubExpr
+          | addOrSubExpr
+
+addOrSubExpr = addOrSubExpr '+' mulOrDivExpr
+             | addOrSubExpr '-' mulOrDivExpr
+             | mulOrDivExpr
+
+mulOrDivExpr = mulOrDivExpr '*' suffixUnaryExpr
+             | mulOrDivExpr '/' suffixUnaryExpr
+             | suffixUnaryExpr
+
+suffixUnaryExpr = prefixUnaryExpr '++'
+                | prefixUnaryExpr '--'
+                | prefixUnaryExpr
+
+prefixUnaryExpr = '-' factorExpr
+                | '~' prefixUnaryExpr
+                | '++' factorExpr
+                | '--' factorExpr
+                | '!' prefixUnaryExpr
+                | '(' TYPE ')' prefixUnaryExpr
+                | factorExpr
+
+factorExpr = factorExpr '.' ID
+           | factorExpr '[' expr ']'
+           | callFuncExpr
+           | ID
+           | NUM_VAL | STRING_VAL | CHAR_VAL | DOUBLE_VAL | FLOAT_VAL
+           | (expr)
+
+callFuncExpr = ID '(' param ')'


### PR DESCRIPTION
This PR pretties the `tins.ebnf` file by following the [EBNF syntax](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form).